### PR TITLE
Add tslint as package dependency and leverage it

### DIFF
--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -1,3 +1,7 @@
+path = require 'path'
+
+tslintPath = path.join __dirname, '..', 'node_modules', 'tslint', 'bin'
+
 module.exports =
   configDefaults:
-    tslintExecutablePath: null
+    tslintExecutablePath: tslintPath

--- a/lib/linter-tslint.coffee
+++ b/lib/linter-tslint.coffee
@@ -21,7 +21,9 @@ class LinterTslint extends Linter
 
   constructor: (editor) ->
     @cwd = path.dirname(editor.getUri())
-    @executablePath = atom.config.get 'linter-tslint.tslintExecutablePath'
+
+    atom.config.observe 'linter-tslint.tslintExecutablePath', (tslintPath) =>
+      @executablePath = tslintPath
 
   getCmd:(filePath) ->
     cmd = super(filePath)

--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
   "engines": {
     "atom": ">0.50.0"
   },
-  "dependencies": {},
+  "dependencies": {
+    "tslint": "^0.4.9"
+  },
   "readmeFilename": "README.md",
   "bugs": {
     "url": "https://github.com/AtomLinter/linter-tslint/issues"


### PR DESCRIPTION
No need to install tslint as a global executable any more. Update the README after this is merged.
