### PR TITLE
Normalize the file path so tslint works for windows

### DIFF
--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -34,7 +34,7 @@ module.exports =
             {
               type: 'Warning'
               text: "#{failure.getRuleName()} - #{failure.getFailure()}"
-              filePath: failure.getFileName(),
+              filePath: path.normalize failure.getFileName()
               range: [
                 [ startPosition.line, startPosition.character],
                 [ endPosition.line, endPosition.character]]


### PR DESCRIPTION
This fixes linter for me on windows, fixes #30 as well.