### PR TITLE
Update Linter.findConfiguration's first parameter to null

### DIFF
--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -29,12 +29,12 @@ module.exports =
       lint: (textEditor) ->
         filePath = textEditor.getPath()
         text = textEditor.getText()
-        configuration = Linter.findConfiguration(undefined, filePath)
-        
+        configuration = Linter.findConfiguration(null, filePath)
+
         directory = undefined
         if (rulesDirectory && textEditor.project && textEditor.project.getPaths().length)
           directory = textEditor.project.getPaths()[0] + path.sep + rulesDirectory
-        
+
         linter = new Linter(filePath, text, {
           formatter: 'json',
           configuration: configuration


### PR DESCRIPTION
Currently, `Linter.findConfiguration` is called with `undefined` as
its first parameter.  This bypasses `tslint`'s configuration-finding
logic, as it explicitly checks for a `null` first parameter.  Therefore
one cannot use `tslint`'s option to set a `tslintConfig` attribute in
`package.json`. This PR corrects that behavior.