### PR TITLE
Added rules option in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,21 @@ Linter package must be installed in order to use this plugin. If Linter is not i
 $ apm install linter-tslint
 ```
 
+### Configuration
+Configuration rules can be defined in atom config like the following as an example.
+```
+"*":
+  "linter-tslint":
+    rules:
+      "variable-name": true
+      quotemark: [
+        true
+        "single"
+        "avoid-escape"
+      ]
+```
+The format of rules is equal to the one in [tslint](https://github.com/palantir/tslint#usage).
+
 ## Contributing
 If you would like to contribute enhancements or fixes, please do the following:
 

--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -1,5 +1,6 @@
 {CompositeDisposable} = require 'atom'
 path = require 'path'
+merge = require 'merge'
 rulesDirectory = ''
 rules = {}
 
@@ -39,7 +40,7 @@ module.exports =
         text = textEditor.getText()
         configuration = Linter.findConfiguration(null, filePath)
         if (rules)
-          configuration.rules = rules
+          configuration.rules = merge(configuration.rules, rules)
 
         directory = undefined
         if (rulesDirectory && textEditor.project && textEditor.project.getPaths().length)

--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -1,6 +1,7 @@
 {CompositeDisposable} = require 'atom'
 path = require 'path'
 rulesDirectory = ''
+rules = {}
 
 module.exports =
 
@@ -9,6 +10,10 @@ module.exports =
       type: 'string'
       title: 'Custom rules directory'
       default: ''
+    rules:
+      type: 'object'
+      title: 'Rules in configuration'
+      default: {}
 
   activate: ->
     @subscriptions = new CompositeDisposable
@@ -16,6 +21,9 @@ module.exports =
     @subscriptions.add atom.config.observe 'linter-tslint.rulesDirectory',
       (dir) =>
         rulesDirectory = dir
+    @subscriptions.add atom.config.observe 'linter-tslint.rules',
+      (obj) =>
+        rules = obj
 
   deactivate: ->
     @subscriptions.dispose()
@@ -30,6 +38,8 @@ module.exports =
         filePath = textEditor.getPath()
         text = textEditor.getText()
         configuration = Linter.findConfiguration(null, filePath)
+        if (rules)
+          configuration.rules = rules
 
         directory = undefined
         if (rulesDirectory && textEditor.project && textEditor.project.getPaths().length)

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "atom": ">0.50.0"
   },
   "dependencies": {
+    "merge": "^1.2.0",
     "tslint": "^3.2.1",
     "typescript": ">=1.7.5"
   },


### PR DESCRIPTION
Except custom rules directory adoption, it looks better define base rule set like tslint configuration with atom config. pros from this feature is that lint result can be real-time changed every change of atom config.