### PR TITLE
Resolve config rules directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [v0.9.0](https://github.com/AtomLinter/linter-tslint/tree/v0.9.0) (2016-03-23)
 
-- corrected ```rulesDirectory``` resolving. ```rulesDirectory``` from settings have to be absolute path [092dbc6b](https://github.com/AtomLinter/linter-tslint/commit/092dbc6be5e89d10ed8f8abfd63b3b5cde365c65) ([arusakov](https://github.com/arusakov))
+- Correct ```rulesDirectory``` resolving. ```rulesDirectory``` from settings have to be an absolute path [47668b81](https://github.com/AtomLinter/linter-tslint/commit/47668b81459113a4478accba64b9a72d18e0b0e8) ([arusakov](https://github.com/arusakov))
 - TypeScript@1.8.9  [d34b74b8](https://github.com/AtomLinter/linter-tslint/commit/d34b74b855217668d6df058e38bc7b7d6a3ddabd) ([greenkeeperio-bot](https://github.com/greenkeeperio-bot))
 - tslint@3.6.0  [b2873a02](https://github.com/AtomLinter/linter-tslint/commit/b2873a02415e125738c5ef6b7eda22c38da831f2) ([greenkeeperio-bot](https://github.com/greenkeeperio-bot))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [v0.9.0](https://github.com/AtomLinter/linter-tslint/tree/v0.9.0) (2016-03-23)
+
+- corrected ```rulesDirectory``` resolving. ```rulesDirectory``` from settings have to be absolute path [092dbc6b](https://github.com/AtomLinter/linter-tslint/commit/092dbc6be5e89d10ed8f8abfd63b3b5cde365c65) ([arusakov](https://github.com/arusakov))
+- TypeScript@1.8.9  [d34b74b8](https://github.com/AtomLinter/linter-tslint/commit/d34b74b855217668d6df058e38bc7b7d6a3ddabd) ([greenkeeperio-bot](https://github.com/greenkeeperio-bot))
+- tslint@3.6.0  [b2873a02](https://github.com/AtomLinter/linter-tslint/commit/b2873a02415e125738c5ef6b7eda22c38da831f2) ([greenkeeperio-bot](https://github.com/greenkeeperio-bot))
+
 ## [v0.8.3](https://github.com/AtomLinter/linter-tslint/tree/v0.8.3) (2016-03-02)
 
 - CHANGELOG.md [aecfe6207](https://github.com/AtomLinter/linter-tslint/commit/aecfe6207672d83ecdea3008c79034cc207bc3ea) ([arusakov](https://github.com/arusakov))

--- a/README.md
+++ b/README.md
@@ -12,6 +12,16 @@ On first activation the plugin will install all dependencies automatically, you 
 $ apm install linter-tslint
 ```
 
+## Settings
+You can configure linter-tslint by editing `~/.atom/config.cson` (choose Config... in Atom menu):
+```coffee
+'linter-tslint':
+  # Custom rules directory (absolute path)
+  rulesDirectory: "/path/to/rules"
+  # Try using the local tslint package (if exist)
+  useLocalTslint: true
+```
+
 ## Contributing
 If you would like to contribute enhancements or fixes, please do the following:
 
@@ -28,6 +38,3 @@ Please note that modifications should follow these coding guidelines:
 - Vertical whitespace helps readability, don’t be afraid to use it.
 
 Thank you for helping out!
-
-## Donation
-[![Share the love!](https://chewbacco-stuff.s3.amazonaws.com/donate.png)](https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=KXUYS4ARNHCN8)

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "atom-package-deps": "4.0.1",
     "resolve": "1.1.7",
     "tslint": "3.6.0",
-    "typescript": "1.8.7"
+    "typescript": "1.8.9"
   },
   "readmeFilename": "README.md",
   "bugs": {


### PR DESCRIPTION
Fix #65 I think.

@Arcanemagus @park9140 

This contains one breaking change. ```rulesDirectory``` from Atom package config has to be absolute path. It is much clearer and better than old resolving: 
```
directory = path.join textEditor.project.getPaths()[0], @rulesDirectory
```
