### PR TITLE
Fix path resolution for custom rules directories

### DIFF
--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -86,7 +86,9 @@ module.exports =
             if not Array.isArray rulesDirectory
               rulesDirectory = [rulesDirectory]
             rulesDirectory = rulesDirectory.map (dir) ->
-              path.join configurationDir, dir
+              if path.isAbsolute dir
+              then dir
+              else path.join configurationDir, dir
 
             if @rulesDirectory
               rulesDirectory.push @rulesDirectory


### PR DESCRIPTION
It seems that tslint may be giving us absolute paths for custom rules definitions (possibly a change of behavior?). This PR changes the behavior to not double-root paths if they are already absolute. 