### PR TITLE
Parse tslint.json using the configured linter.

### DIFF
--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -77,8 +77,8 @@ module.exports =
         text = textEditor.getText()
 
         @getLinter(filePath).then (Linter) =>
-          configurationPath = @tslintDef.findConfigurationPath null, filePath
-          configuration = @tslintDef.loadConfigurationFromPath configurationPath
+          configurationPath = Linter.findConfigurationPath null, filePath
+          configuration = Linter.loadConfigurationFromPath configurationPath
 
           rulesDirectory = configuration.rulesDirectory
           if rulesDirectory


### PR DESCRIPTION
Currently, the linter configuration (tslint.json) is located and parsed using the tslint module packaged with the plugin. This is incorrect when another version of tslint is in use, which happens when useLocalTslint is true, and a suitable tslint version is found.

This is preventing me from using this atom plugin, because I'm using a tslint version that allows comments in the JSON configuration, but the tslint packaged with atom doesn't support that yet. In any case, it seems wrong to parse the configuration with one version of tslint, and then use it with another version.

Please consider merging this, and thank you very much for your work on this plugin!