### PR TITLE
Use `loophole` package to to fix #104

### DIFF
--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -59,14 +59,16 @@ module.exports =
       requireResolve TSLINT_MODULE_NAME, { basedir },
         (err, linterPath, pkg) =>
           if not err and pkg?.version.startsWith '3.'
-            linter = require linterPath
+            linter = require('loophole').allowUnsafeNewFunction ->
+              require linterPath
           else
             linter = @tslintDef
           @tslintCache.set basedir, linter
           resolve(linter)
 
   provideLinter: ->
-    @tslintDef = require TSLINT_MODULE_NAME
+    @tslintDef = require('loophole').allowUnsafeNewFunction ->
+      require TSLINT_MODULE_NAME
 
     provider =
       grammarScopes: @scopes

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "atom-package-deps": "4.0.1",
+    "loophole": "^1.1.0",
     "resolve": "1.1.7",
     "tslint": "3.14.0",
     "typescript": "1.8.10"


### PR DESCRIPTION
Atom packages are running with Content Security Policy (CSP) set to disallow `eval-like` behavior. Recent change in Typescript (https://github.com/Microsoft/TypeScript/pull/9580) added code that uses `new Function(...)` which will cause `linter-tslint` package to fail to initialize with the error as seen in #104.

This PR uses package `loophole` (https://github.com/atom/loophole) created by the Atom team to specifically address issues like this. I've also commented on the above mentioned PR and will try to open an issue with the Typescript team. Meanwhile, this workaround restores functionality of `linter-tslint` when used with `typescript@next`.