### PR TITLE
Add basic specs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,41 @@
-language: node_js
-node_js:
-  - "4.1"
-env:
-  - CXX=g++-4.8
+### Project specific config ###
+language: generic
+
+matrix:
+  include:
+    - os: linux
+      env: ATOM_CHANNEL=stable
+
+    - os: linux
+      env: ATOM_CHANNEL=beta
+
+    - os: osx
+      env: ATOM_CHANNEL=stable
+
+### Generic setup follows ###
+script:
+  - curl -s -O https://raw.githubusercontent.com/atom/ci/master/build-package.sh
+  - chmod u+x build-package.sh
+  - ./build-package.sh
+
+notifications:
+  email:
+    on_success: never
+    on_failure: change
+
+branches:
+  only:
+    - master
+
+git:
+  depth: 10
+
+sudo: false
+
 addons:
   apt:
-    sources:
-      - ubuntu-toolchain-r-test
     packages:
-      - g++-4.8
+    - build-essential
+    - git
+    - libgnome-keyring-dev
+    - fakeroot

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "url": "https://github.com/AtomLinter/linter-tslint.git"
   },
   "scripts": {
-    "test": "npm run lint",
-    "lint": "coffeelint ./lib"
+    "test": "apm test",
+    "lint": "coffeelint lib && eslint ."
   },
   "license": "MIT",
   "engines": {
@@ -42,6 +42,31 @@
     }
   },
   "devDependencies": {
-    "coffeelint": "1.15.7"
+    "coffeelint": "1.15.7",
+    "eslint": "^3.6.0",
+    "eslint-config-airbnb-base": "^8.0.0",
+    "eslint-plugin-import": "^1.16.0"
+  },
+  "eslintConfig": {
+    "extends": "airbnb-base",
+    "rules": {
+      "global-require": "off",
+      "import/no-unresolved": [
+        "error",
+        {
+          "ignore": [
+            "atom"
+          ]
+        }
+      ]
+    },
+    "env": {
+      "es6": true,
+      "browser": true,
+      "node": true
+    },
+    "globals": {
+      "atom": true
+    }
   }
 }

--- a/spec/.eslintrc.js
+++ b/spec/.eslintrc.js
@@ -1,0 +1,6 @@
+module.exports = {
+  env: {
+    jasmine: true,
+    atomtest: true
+  }
+};

--- a/spec/fixtures/invalid/invalid.ts
+++ b/spec/fixtures/invalid/invalid.ts
@@ -1,0 +1,2 @@
+const foo = 42
+export default foo;

--- a/spec/fixtures/invalid/tsconfig.json
+++ b/spec/fixtures/invalid/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "compileOnSave": false,
+  "buildOnSave": false,
+  "atom": {
+    "rewriteTsconfig": false
+  }
+}

--- a/spec/fixtures/invalid/tslint.json
+++ b/spec/fixtures/invalid/tslint.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "semicolon": true
+  }
+}

--- a/spec/fixtures/valid/tsconfig.json
+++ b/spec/fixtures/valid/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "compileOnSave": false,
+  "buildOnSave": false,
+  "atom": {
+    "rewriteTsconfig": false
+  }
+}

--- a/spec/fixtures/valid/tslint.json
+++ b/spec/fixtures/valid/tslint.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "semicolon": true
+  }
+}

--- a/spec/fixtures/valid/valid.ts
+++ b/spec/fixtures/valid/valid.ts
@@ -1,0 +1,2 @@
+const foo = 42;
+export default foo;

--- a/spec/linter-tslint-spec.js
+++ b/spec/linter-tslint-spec.js
@@ -1,0 +1,42 @@
+'use babel';
+
+import * as path from 'path';
+
+const validPath = path.join(__dirname, 'fixtures', 'valid', 'valid.ts');
+const invalidPath = path.join(__dirname, 'fixtures', 'invalid', 'invalid.ts');
+
+describe('The TSLint provider for Linter', () => {
+  const lint = require('../lib/init.coffee').provideLinter().lint;
+
+  beforeEach(() => {
+    atom.workspace.destroyActivePaneItem();
+
+    waitsForPromise(() =>
+      Promise.all([
+        atom.packages.activatePackage('linter-tslint'),
+      ])
+    );
+  });
+
+  it('finds nothing wrong with a valid file', () => {
+    waitsForPromise(() =>
+      atom.workspace.open(validPath).then(editor => lint(editor)).then((messages) => {
+        expect(messages.length).toBe(0);
+      })
+    );
+  });
+
+  it('handles messages from TSLint', () => {
+    const expectedMsg = 'semicolon - Missing semicolon';
+    waitsForPromise(() =>
+      atom.workspace.open(invalidPath).then(editor => lint(editor)).then((messages) => {
+        expect(messages.length).toBe(1);
+        expect(messages[0].type).toBe('Warning');
+        expect(messages[0].html).not.toBeDefined();
+        expect(messages[0].text).toBe(expectedMsg);
+        expect(messages[0].filePath).toBe(invalidPath);
+        expect(messages[0].range).toEqual([[0, 14], [0, 14]]);
+      })
+    );
+  });
+});


### PR DESCRIPTION
Add some specs testing that the linter is working. Also brings in and configures ESLint to lint the specs.

This also fixes the CI testing, as the previous tests weren't testing this package at all, and without specs they couldn't be updated.

Fixes #48.