### PR TITLE
Update for TSLint v4

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -11,6 +11,35 @@ const TSLINT_MODULE_NAME = 'tslint';
 const tslintCache = new Map();
 let tslintDef = null;
 
+/**
+ * Shim for TSLint v3 interoperability
+ * @param {Function} Linter TSLint v3 linter
+ * @return {Function} TSLint v4-compatible linter
+ */
+function shim(Linter) {
+  function LinterShim(options) {
+    this.options = options;
+    this.results = {};
+  }
+
+  // Assign class properties
+  Object.assign(LinterShim, Linter);
+
+  // Assign instance methods
+  LinterShim.prototype = Object.assign({}, Linter.prototype, {
+    lint(filePath, text, configuration) {
+      const options = Object.assign({}, this.options, { configuration });
+      const linter = new Linter(filePath, text, options);
+      this.results = linter.lint();
+    },
+    getResult() {
+      return this.results;
+    },
+  });
+
+  return LinterShim;
+}
+
 export default {
   activate() {
     require('atom-package-deps').install('linter-tslint');
@@ -60,9 +89,14 @@ export default {
       requireResolve(TSLINT_MODULE_NAME, { basedir },
         (err, linterPath, pkg) => {
           let linter;
-          if (!err && pkg && pkg.version.startsWith('3.')) {
-            // eslint-disable-next-line import/no-dynamic-require
-            linter = require('loophole').allowUnsafeNewFunction(() => require(linterPath));
+          if (!err && pkg && /^3|4\./.test(pkg.version)) {
+            if (pkg.version.startsWith('3')) {
+              // eslint-disable-next-line import/no-dynamic-require
+              linter = shim(require('loophole').allowUnsafeNewFunction(() => require(linterPath)));
+            } else if (pkg.version.startsWith('4')) {
+              // eslint-disable-next-line import/no-dynamic-require
+              linter = require('loophole').allowUnsafeNewFunction(() => require(linterPath).Linter);
+            }
           } else {
             linter = tslintDef;
           }
@@ -75,7 +109,7 @@ export default {
 
   provideLinter() {
     // eslint-disable-next-line import/no-dynamic-require
-    tslintDef = require('loophole').allowUnsafeNewFunction(() => require(TSLINT_MODULE_NAME));
+    tslintDef = require('loophole').allowUnsafeNewFunction(() => require(TSLINT_MODULE_NAME).Linter);
 
     return {
       grammarScopes: ['source.ts', 'source.tsx'],
@@ -107,13 +141,13 @@ export default {
             }
           }
 
-          const linter = new Linter(filePath, text, {
+          const linter = new Linter({
             formatter: 'json',
-            configuration,
             rulesDirectory,
           });
 
-          const lintResult = linter.lint();
+          linter.lint(filePath, text, configuration);
+          const lintResult = linter.getResult();
 
           if (textEditor.getText() !== text) {
             // Text has been modified since the lint was triggered, tell linter not to update

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "atom-package-deps": "4.3.1",
     "loophole": "^1.1.0",
     "resolve": "1.1.7",
-    "tslint": "3.15.1",
+    "tslint": "4.0.2",
     "typescript": "2.0.6"
   },
   "readmeFilename": "README.md",


### PR DESCRIPTION
Thanks for `linter-tslint`! It doesn't seem to work with the latest version of `tslint`, so I've updated the source to work with TSLint v4.

It all seems to work fine for me – let me know if there's anything I can help with to get this merged!