### PR TITLE
Update ESLint configuration

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -54,14 +54,14 @@ export default {
             }
           });
         }
-      })
+      }),
     );
 
     this.subscriptions.add(
       atom.config.observe('linter-tslint.useLocalTslint', (use) => {
         tslintCache.clear();
         this.useLocalTslint = use;
-      })
+      }),
     );
   },
 
@@ -102,8 +102,8 @@ export default {
           }
           tslintCache.set(basedir, linter);
           return resolve(linter);
-        }
-      )
+        },
+      ),
     );
   },
 

--- a/package.json
+++ b/package.json
@@ -54,9 +54,9 @@
     }
   },
   "devDependencies": {
-    "eslint": "^3.6.0",
-    "eslint-config-airbnb-base": "^8.0.0",
-    "eslint-plugin-import": "^1.16.0"
+    "eslint": "^3.9.1",
+    "eslint-config-airbnb-base": "^10.0.1",
+    "eslint-plugin-import": "^2.1.0"
   },
   "eslintConfig": {
     "extends": "airbnb-base",
@@ -72,7 +72,6 @@
       ]
     },
     "env": {
-      "es6": true,
       "browser": true,
       "node": true
     },

--- a/spec/linter-tslint-spec.js
+++ b/spec/linter-tslint-spec.js
@@ -14,7 +14,7 @@ describe('The TSLint provider for Linter', () => {
     waitsForPromise(() =>
       Promise.all([
         atom.packages.activatePackage('linter-tslint'),
-      ])
+      ]),
     );
   });
 
@@ -22,7 +22,7 @@ describe('The TSLint provider for Linter', () => {
     waitsForPromise(() =>
       atom.workspace.open(validPath).then(editor => lint(editor)).then((messages) => {
         expect(messages.length).toBe(0);
-      })
+      }),
     );
   });
 
@@ -36,7 +36,7 @@ describe('The TSLint provider for Linter', () => {
         expect(messages[0].text).toBe(expectedMsg);
         expect(messages[0].filePath).toBe(invalidPath);
         expect(messages[0].range).toEqual([[0, 14], [0, 14]]);
-      })
+      }),
     );
   });
 });


### PR DESCRIPTION
Update to `eslint-config-airbnb-base@10.0.1` including updates to `eslint@^3.9.1` and `eslint-plugin-import@^2.1.0` to satisfy its peerDependencies. Cleans up the configuration a tiny bit and fixes the new lint issues.

Closes #118.
Closes #119.