### PR TITLE
Whitelist the Greenkeeper branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ notifications:
 branches:
   only:
     - master
+    - /^greenkeeper/.*$/
 
 git:
   depth: 10


### PR DESCRIPTION
Whitelist the Greenkeeper branches so it can fully test dependency
updates.