### PR TITLE
support tslint@5

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -93,7 +93,7 @@ export default {
             if (pkg.version.startsWith('3')) {
               // eslint-disable-next-line import/no-dynamic-require
               linter = shim(require('loophole').allowUnsafeNewFunction(() => require(linterPath)));
-            } else if (pkg.version.startsWith('4') || pkg.version.startsWith('5')) {
+            } else {
               // eslint-disable-next-line import/no-dynamic-require
               linter = require('loophole').allowUnsafeNewFunction(() => require(linterPath).Linter);
             }

--- a/lib/main.js
+++ b/lib/main.js
@@ -89,11 +89,11 @@ export default {
       requireResolve(TSLINT_MODULE_NAME, { basedir },
         (err, linterPath, pkg) => {
           let linter;
-          if (!err && pkg && /^3|4\./.test(pkg.version)) {
+          if (!err && pkg && /^3|4|5\./.test(pkg.version)) {
             if (pkg.version.startsWith('3')) {
               // eslint-disable-next-line import/no-dynamic-require
               linter = shim(require('loophole').allowUnsafeNewFunction(() => require(linterPath)));
-            } else if (pkg.version.startsWith('4')) {
+            } else if (pkg.version.startsWith('4') || pkg.version.startsWith('5')) {
               // eslint-disable-next-line import/no-dynamic-require
               linter = require('loophole').allowUnsafeNewFunction(() => require(linterPath).Linter);
             }
@@ -154,7 +154,14 @@ export default {
             return null;
           }
 
-          if (!lintResult.failureCount) {
+          if (
+            // tslint@<5
+            !lintResult.failureCount &&
+            // tslint@>=5
+            !lintResult.errorCount &&
+            !lintResult.warningCount &&
+            !lintResult.infoCount
+          ) {
             return [];
           }
 
@@ -162,7 +169,7 @@ export default {
             const startPosition = failure.getStartPosition().getLineAndCharacter();
             const endPosition = failure.getEndPosition().getLineAndCharacter();
             return {
-              type: 'Warning',
+              type: failure.ruleSeverity || 'Warning',
               text: `${failure.getRuleName()} - ${failure.getFailure()}`,
               filePath: path.normalize(failure.getFileName()),
               range: [


### PR DESCRIPTION
It uses the rules severity if there (if the project uses tslint@5), but defaults to warning, like before.