### PR TITLE
Updating UTs to support both TSLint4 and TSLint5 issues

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -231,7 +231,7 @@ export default {
       const startPosition = failure.getStartPosition().getLineAndCharacter();
       const endPosition = failure.getEndPosition().getLineAndCharacter();
       return {
-        type: failure.ruleSeverity || 'Warning',
+        type: failure.ruleSeverity || 'warning',
         text: `${failure.getRuleName()} - ${failure.getFailure()}`,
         filePath: path.normalize(failure.getFileName()),
         range: [

--- a/spec/fixtures/invalid/tslint.json
+++ b/spec/fixtures/invalid/tslint.json
@@ -1,4 +1,5 @@
 {
+  "defaultSeverity": "warning",
   "rules": {
     "semicolon": true
   }

--- a/spec/linter-tslint-spec.js
+++ b/spec/linter-tslint-spec.js
@@ -31,7 +31,7 @@ describe('The TSLint provider for Linter', () => {
     waitsForPromise(() =>
       atom.workspace.open(invalidPath).then(editor => lint(editor)).then((messages) => {
         expect(messages.length).toBe(1);
-        expect(messages[0].type).toBe('Warning');
+        expect(messages[0].type).toBe('warning');
         expect(messages[0].html).not.toBeDefined();
         expect(messages[0].text).toBe(expectedMsg);
         expect(messages[0].filePath).toBe(invalidPath);


### PR DESCRIPTION
In addition, the severity returned by this package was "Warning" (upper-case 'W') which according to [this](https://github.com/steelbrain/linter/blob/master/lib/validate/index.js) isn't valid.