### PR TITLE
Reduce activation time

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -1,17 +1,17 @@
 'use babel';
 
-/* eslint-disable import/extensions, import/no-extraneous-dependencies */
+// eslint-disable-next-line import/extensions, import/no-extraneous-dependencies
 import { CompositeDisposable } from 'atom';
-/* eslint-enable import/extensions, import/no-extraneous-dependencies */
 import path from 'path';
 import fs from 'fs';
-import requireResolve from 'resolve';
 
 const TSLINT_MODULE_NAME = 'tslint';
 const grammarScopes = ['source.ts', 'source.tsx'];
 const editorClass = 'linter-tslint-compatible-editor';
 const tslintCache = new Map();
-let tslintDef = null;
+let tslintDef;
+let requireResolve;
+const idleCallbacks = new Set();
 
 /**
  * Shim for TSLint v3 interoperability
@@ -42,9 +42,26 @@ function shim(Linter) {
   return LinterShim;
 }
 
+function loadDefaultTSLint() {
+  if (!tslintDef) {
+    tslintDef = require('loophole').allowUnsafeNewFunction(() =>
+      // eslint-disable-next-line import/no-dynamic-require
+      require(TSLINT_MODULE_NAME).Linter);
+  }
+}
+
 export default {
   activate() {
-    require('atom-package-deps').install('linter-tslint');
+    let depsCallbackID;
+    const lintertslintDeps = () => {
+      idleCallbacks.delete(depsCallbackID);
+      // Install package dependencies
+      require('atom-package-deps').install('linter-tslint');
+      // Initialize the default TSLint instance
+      loadDefaultTSLint();
+    };
+    depsCallbackID = window.requestIdleCallback(lintertslintDeps);
+    idleCallbacks.add(depsCallbackID);
 
     this.subscriptions = new CompositeDisposable();
 
@@ -117,15 +134,19 @@ export default {
   },
 
   deactivate() {
+    idleCallbacks.forEach(callbackID => window.cancelIdleCallback(callbackID));
+    idleCallbacks.clear();
     this.subscriptions.dispose();
   },
 
   async getLinter(filePath) {
     const basedir = path.dirname(filePath);
-    const linter = tslintCache.get(basedir);
-    if (linter) {
-      return linter;
+    if (tslintCache.has(basedir)) {
+      return tslintCache.get(basedir);
     }
+
+    // Initialize the default instance if it hasn't already been initialized
+    loadDefaultTSLint();
 
     if (this.useLocalTslint) {
       return this.getLocalLinter(basedir);
@@ -136,7 +157,10 @@ export default {
   },
 
   async getLocalLinter(basedir) {
-    return new Promise(resolve =>
+    return new Promise((resolve) => {
+      if (!requireResolve) {
+        requireResolve = require('resolve');
+      }
       requireResolve(TSLINT_MODULE_NAME, { basedir },
         (err, linterPath, pkg) => {
           let linter;
@@ -154,14 +178,11 @@ export default {
           tslintCache.set(basedir, linter);
           return resolve(linter);
         },
-      ),
-    );
+      );
+    });
   },
 
   provideLinter() {
-    // eslint-disable-next-line import/no-dynamic-require
-    tslintDef = require('loophole').allowUnsafeNewFunction(() => require(TSLINT_MODULE_NAME).Linter);
-
     return {
       name: 'TSLint',
       grammarScopes,


### PR DESCRIPTION
Reduce the activation time by:
* Defering dependency loading till necessary
* Pushing package dependency checking into an idle callback

On my "pristine" profile this brings activation from an average of 350.8 ms down to 6.8 ms.