### PR TITLE
Pass a program object to the linter to enable type checking

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ You can configure linter-tslint by editing `~/.atom/config.cson` (choose Config.
   rulesDirectory: "/path/to/rules"
   # Try using the local tslint package (if exist)
   useLocalTslint: true
+  # Enable semantic rules
+  enableSemanticRules: true
 ```
 
 ## Contributing

--- a/lib/main.js
+++ b/lib/main.js
@@ -55,6 +55,10 @@ export default {
         config.useLocalTslint = use;
         workerHelper.changeConfig('useLocalTslint', use);
       }),
+      atom.config.observe('linter-tslint.enableSemanticRules', (enableSemanticRules) => {
+        config.enableSemanticRules = enableSemanticRules;
+        workerHelper.changeConfig('enableSemanticRules', enableSemanticRules);
+      }),
       atom.config.observe('linter-tslint.ignoreTypings', (ignoreTypings) => {
         this.ignoreTypings = ignoreTypings;
       }),

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -112,8 +112,7 @@ async function getProgram(Linter, configurationPath) {
   const tsconfigPath = path.resolve(configurationDir, 'tsconfig.json');
   try {
     const stats = await stat(tsconfigPath);
-    const isFile = stats.isFile();
-    if (isFile) {
+    if (stats.isFile()) {
       program = Linter.createProgram('tsconfig.json', configurationDir);
     }
   } catch (err) {

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -3,6 +3,7 @@
 /* global emit */
 
 import path from 'path';
+import fs from 'fs';
 
 process.title = 'linter-tslint worker';
 
@@ -14,6 +15,17 @@ const config = {
 
 let tslintDef;
 let requireResolve;
+
+async function stat(pathname) {
+  return new Promise((resolve, reject) => {
+    fs.stat(pathname, (err, stats) => {
+      if (err) {
+        return reject(err);
+      }
+      return resolve(stats);
+    });
+  });
+}
 
 /**
  * Shim for TSLint v3 interoperability
@@ -94,6 +106,22 @@ async function getLinter(filePath) {
   return tslintDef;
 }
 
+async function getProgram(Linter, configurationPath) {
+  let program;
+  const configurationDir = path.dirname(configurationPath);
+  const tsconfigPath = path.resolve(configurationDir, 'tsconfig.json');
+  try {
+    const stats = await stat(tsconfigPath);
+    const isFile = stats.isFile();
+    if (isFile) {
+      program = Linter.createProgram('tsconfig.json', configurationDir);
+    }
+  } catch (err) {
+    // no-op
+  }
+  return program;
+}
+
 /**
  * Lint the provided TypeScript content
  * @param content {string} The content of the TypeScript file
@@ -128,10 +156,14 @@ async function lint(content, filePath, options) {
     }
   }
 
+  let program;
+  if (config.enableSemanticRules && configurationPath) {
+    program = await getProgram(Linter, configurationPath);
+  }
   const linter = new Linter(Object.assign({
     formatter: 'json',
     rulesDirectory,
-  }, options));
+  }, options), program);
 
   linter.lint(filePath, content, configuration);
   const lintResult = linter.getResult();
@@ -164,6 +196,7 @@ async function lint(content, filePath, options) {
 
 export default async function (initialConfig) {
   config.useLocalTslint = initialConfig.useLocalTslint;
+  config.enableSemanticRules = initialConfig.enableSemanticRules;
 
   process.on('message', async (message) => {
     if (message.messageType === 'config') {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "enableSemanticRules": {
       "type": "boolean",
       "title": "Enable semantic rules",
-      "description": "Pass a TypeScript program object to the linter. May negatively affect performance. See this page for details: https://palantir.github.io/tslint/usage/type-checking/",
+      "description": "Allow passing a TypeScript program object to the linter. May negatively affect performance. See this page for details: https://palantir.github.io/tslint/usage/type-checking/",
       "default": false
     },
     "ignoreTypings": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,12 @@
       "title": "Try using the local tslint package (if exist)",
       "default": true
     },
+    "enableSemanticRules": {
+      "type": "boolean",
+      "title": "Enable semantic rules",
+      "description": "Pass a TypeScript program object to the linter. May negatively affect performance. See this page for details: https://palantir.github.io/tslint/usage/type-checking/",
+      "default": false
+    },
     "ignoreTypings": {
       "type": "boolean",
       "title": "Ignore typings files (.d.ts)",

--- a/spec/fixtures/invalid-typechecked/invalid-typechecked.ts
+++ b/spec/fixtures/invalid-typechecked/invalid-typechecked.ts
@@ -1,0 +1,3 @@
+export default () => {
+  const foo = 42;
+}

--- a/spec/fixtures/invalid-typechecked/invalid-typechecked.ts
+++ b/spec/fixtures/invalid-typechecked/invalid-typechecked.ts
@@ -1,3 +1,2 @@
-export default () => {
-  const foo = 42;
-}
+declare const x: boolean;
+x === true;

--- a/spec/fixtures/invalid-typechecked/tsconfig.json
+++ b/spec/fixtures/invalid-typechecked/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "compileOnSave": false,
+  "buildOnSave": false,
+  "atom": {
+    "rewriteTsconfig": false
+  }
+}

--- a/spec/fixtures/invalid-typechecked/tslint.json
+++ b/spec/fixtures/invalid-typechecked/tslint.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "no-unused-variable": true
+  }
+}

--- a/spec/fixtures/invalid-typechecked/tslint.json
+++ b/spec/fixtures/invalid-typechecked/tslint.json
@@ -1,5 +1,8 @@
 {
+  "linterOptions": {
+    "typeCheck": true
+  },
   "rules": {
-    "no-unused-variable": true
+    "no-boolean-literal-compare": true
   }
 }

--- a/spec/fixtures/valid-typechecked/tsconfig.json
+++ b/spec/fixtures/valid-typechecked/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "compileOnSave": false,
+  "buildOnSave": false,
+  "atom": {
+    "rewriteTsconfig": false
+  }
+}

--- a/spec/fixtures/valid-typechecked/tslint.json
+++ b/spec/fixtures/valid-typechecked/tslint.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "no-unused-variable": true
+  }
+}

--- a/spec/fixtures/valid-typechecked/tslint.json
+++ b/spec/fixtures/valid-typechecked/tslint.json
@@ -1,5 +1,8 @@
 {
+  "linterOptions": {
+    "typeCheck": true
+  },
   "rules": {
-    "no-unused-variable": true
+    "no-boolean-literal-compare": true
   }
 }

--- a/spec/fixtures/valid-typechecked/valid-typechecked.ts
+++ b/spec/fixtures/valid-typechecked/valid-typechecked.ts
@@ -1,0 +1,4 @@
+export default () => {
+  const foo = 42;
+  return foo;
+}

--- a/spec/fixtures/valid-typechecked/valid-typechecked.ts
+++ b/spec/fixtures/valid-typechecked/valid-typechecked.ts
@@ -1,4 +1,2 @@
-export default () => {
-  const foo = 42;
-  return foo;
-}
+declare const x: boolean;
+x;

--- a/spec/linter-tslint-spec.js
+++ b/spec/linter-tslint-spec.js
@@ -3,9 +3,7 @@
 import * as path from 'path';
 
 const validPath = path.join(__dirname, 'fixtures', 'valid', 'valid.ts');
-const validTypecheckedPath = path.join(__dirname, 'fixtures', 'valid-typechecked', 'valid-typechecked.ts');
 const invalidPath = path.join(__dirname, 'fixtures', 'invalid', 'invalid.ts');
-const invalidTypecheckedPath = path.join(__dirname, 'fixtures', 'invalid-typechecked', 'invalid-typechecked.ts');
 
 describe('The TSLint provider for Linter', () => {
   const lint = require('../lib/main.js').provideLinter().lint;
@@ -28,14 +26,6 @@ describe('The TSLint provider for Linter', () => {
     );
   });
 
-  it('finds nothing wrong with a valid file (typechecked)', () => {
-    waitsForPromise(() =>
-      atom.workspace.open(validTypecheckedPath).then(editor => lint(editor)).then((messages) => {
-        expect(messages.length).toBe(0);
-      }),
-    );
-  });
-
   it('handles messages from TSLint', () => {
     const expectedMsg = 'semicolon - Missing semicolon';
     waitsForPromise(() =>
@@ -50,7 +40,46 @@ describe('The TSLint provider for Linter', () => {
     );
   });
 
-  it('handles messages from TSLint (typechecked)', () => {
+  it('handles undefined filepath', () => {
+    waitsForPromise(() =>
+      atom.workspace.open().then(editor => lint(editor)).then((result) => {
+        expect(result).toBeNull();
+      }),
+    );
+  });
+});
+
+const validTypecheckedPath = path.join(__dirname, 'fixtures', 'valid-typechecked', 'valid-typechecked.ts');
+const invalidTypecheckedPath = path.join(__dirname, 'fixtures', 'invalid-typechecked', 'invalid-typechecked.ts');
+
+describe('The TSLint provider for Linter (with semantic rules)', () => {
+  const lint = require('../lib/main.js').provideLinter().lint;
+
+  beforeEach(() => {
+    atom.workspace.destroyActivePaneItem();
+
+    waitsForPromise(() =>
+      Promise.all([
+        atom.packages.activatePackage('linter-tslint'),
+      ]),
+    );
+
+    atom.config.set('linter-tslint.enableSemanticRules', true);
+  });
+
+  afterEach(() => {
+    atom.config.set('linter-tslint.enableSemanticRules', false);
+  });
+
+  it('finds nothing wrong with a valid file', () => {
+    waitsForPromise(() =>
+      atom.workspace.open(validTypecheckedPath).then(editor => lint(editor)).then((messages) => {
+        expect(messages.length).toBe(0);
+      }),
+    );
+  });
+
+  it('handles messages from TSLint', () => {
     const expectedMsg = 'no-unused-variable - \'foo\' is declared but never used.';
     waitsForPromise(() =>
       atom.workspace.open(invalidTypecheckedPath).then(editor => lint(editor)).then((messages) => {
@@ -60,14 +89,6 @@ describe('The TSLint provider for Linter', () => {
         expect(messages[0].text).toBe(expectedMsg);
         expect(messages[0].filePath).toBe(invalidTypecheckedPath);
         expect(messages[0].range).toEqual([[1, 8], [1, 11]]);
-      }),
-    );
-  });
-
-  it('handles undefined filepath', () => {
-    waitsForPromise(() =>
-      atom.workspace.open().then(editor => lint(editor)).then((result) => {
-        expect(result).toBeNull();
       }),
     );
   });

--- a/spec/linter-tslint-spec.js
+++ b/spec/linter-tslint-spec.js
@@ -3,7 +3,9 @@
 import * as path from 'path';
 
 const validPath = path.join(__dirname, 'fixtures', 'valid', 'valid.ts');
+const validTypecheckedPath = path.join(__dirname, 'fixtures', 'valid-typechecked', 'valid-typechecked.ts');
 const invalidPath = path.join(__dirname, 'fixtures', 'invalid', 'invalid.ts');
+const invalidTypecheckedPath = path.join(__dirname, 'fixtures', 'invalid-typechecked', 'invalid-typechecked.ts');
 
 describe('The TSLint provider for Linter', () => {
   const lint = require('../lib/main.js').provideLinter().lint;
@@ -26,6 +28,14 @@ describe('The TSLint provider for Linter', () => {
     );
   });
 
+  it('finds nothing wrong with a valid file (typechecked)', () => {
+    waitsForPromise(() =>
+      atom.workspace.open(validTypecheckedPath).then(editor => lint(editor)).then((messages) => {
+        expect(messages.length).toBe(0);
+      }),
+    );
+  });
+
   it('handles messages from TSLint', () => {
     const expectedMsg = 'semicolon - Missing semicolon';
     waitsForPromise(() =>
@@ -36,6 +46,20 @@ describe('The TSLint provider for Linter', () => {
         expect(messages[0].text).toBe(expectedMsg);
         expect(messages[0].filePath).toBe(invalidPath);
         expect(messages[0].range).toEqual([[0, 14], [0, 14]]);
+      }),
+    );
+  });
+
+  it('handles messages from TSLint (typechecked)', () => {
+    const expectedMsg = 'no-unused-variable - \'foo\' is declared but never used.';
+    waitsForPromise(() =>
+      atom.workspace.open(invalidTypecheckedPath).then(editor => lint(editor)).then((messages) => {
+        expect(messages.length).toBe(1);
+        expect(messages[0].type).toBe('error');
+        expect(messages[0].html).not.toBeDefined();
+        expect(messages[0].text).toBe(expectedMsg);
+        expect(messages[0].filePath).toBe(invalidTypecheckedPath);
+        expect(messages[0].range).toEqual([[1, 8], [1, 11]]);
       }),
     );
   });

--- a/spec/linter-tslint-spec.js
+++ b/spec/linter-tslint-spec.js
@@ -80,7 +80,7 @@ describe('The TSLint provider for Linter (with semantic rules)', () => {
   });
 
   it('handles messages from TSLint', () => {
-    const expectedMsg = 'no-unused-variable - \'foo\' is declared but never used.';
+    const expectedMsg = 'no-boolean-literal-compare - This expression is unnecessarily compared to a boolean. Just use it directly.';
     waitsForPromise(() =>
       atom.workspace.open(invalidTypecheckedPath).then(editor => lint(editor)).then((messages) => {
         expect(messages.length).toBe(1);
@@ -88,7 +88,7 @@ describe('The TSLint provider for Linter (with semantic rules)', () => {
         expect(messages[0].html).not.toBeDefined();
         expect(messages[0].text).toBe(expectedMsg);
         expect(messages[0].filePath).toBe(invalidTypecheckedPath);
-        expect(messages[0].range).toEqual([[1, 8], [1, 11]]);
+        expect(messages[0].range).toEqual([[1, 0], [1, 1]]);
       }),
     );
   });


### PR DESCRIPTION
Attempting to fix #109 (building on @zaggino’s code snippet in that issue)

# Introduction
This PR enables [semantic rules](https://palantir.github.io/tslint/usage/type-checking/) by passing a program object to the linter to enable type checking. This resolves warnings that appear in the developer tools console (<kbd>Command</kbd><kbd>Option</kbd><kbd>i</kbd>) when certain TSLint rules are used, e.g.:
```
Warning: The 'no-unused-variable' rule requires type checking
```

# Warning
This code makes `linter-tslint` runs very slowly on my machine. Warnings like this appear:
```
Handling of 'mousewheel' input event was delayed for 16200 ms due to main thread being busy. Consider marking event handler as 'passive' to make the page more responive.
```
I’m not sure how to resolve this. Any suggestions are welcomed.