### PR TITLE
Fixing bug where the worker thread would hang if there wasn't a tslint.json file

### DIFF
--- a/lib/worker.js
+++ b/lib/worker.js
@@ -111,7 +111,7 @@ async function lint(content, filePath, options) {
   const configuration = Linter.loadConfigurationFromPath(configurationPath);
 
   let { rulesDirectory } = configuration;
-  if (rulesDirectory) {
+  if (rulesDirectory && configurationPath) {
     const configurationDir = path.dirname(configurationPath);
     if (!Array.isArray(rulesDirectory)) {
       rulesDirectory = [rulesDirectory];

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -123,8 +123,8 @@ async function lint(content, filePath, options) {
       return path.join(configurationDir, dir);
     });
 
-    if (rulesDirectory) {
-      rulesDirectory.push(rulesDirectory);
+    if (config.rulesDirectory) {
+      rulesDirectory.push(config.rulesDirectory);
     }
   }
 
@@ -133,8 +133,13 @@ async function lint(content, filePath, options) {
     rulesDirectory,
   }, options));
 
-  linter.lint(filePath, content, configuration);
-  const lintResult = linter.getResult();
+  let lintResult;
+  try {
+    linter.lint(filePath, content, configuration);
+    lintResult = linter.getResult();
+  } catch (err) {
+    lintResult = {};
+  }
 
   if (
     // tslint@<5

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -138,6 +138,7 @@ async function lint(content, filePath, options) {
     linter.lint(filePath, content, configuration);
     lintResult = linter.getResult();
   } catch (err) {
+    console.error(err); // eslint-disable-line no-console
     lintResult = {};
   }
 

--- a/package.json
+++ b/package.json
@@ -67,7 +67,8 @@
   "devDependencies": {
     "eslint": "^3.16.1",
     "eslint-config-airbnb-base": "^11.1.1",
-    "eslint-plugin-import": "^2.2.0"
+    "eslint-plugin-import": "^2.2.0",
+    "jasmine-fix": "^1.0.1"
   },
   "eslintConfig": {
     "extends": "airbnb-base",

--- a/spec/fixtures/no-config/noConfig.ts
+++ b/spec/fixtures/no-config/noConfig.ts
@@ -1,0 +1,2 @@
+const foo = 42;
+export default foo;

--- a/spec/linter-tslint-spec.js
+++ b/spec/linter-tslint-spec.js
@@ -1,6 +1,7 @@
 'use babel';
 
 import * as path from 'path';
+// NOTE: If using 'fit' you must add it to the list below!
 import { beforeEach, it } from 'jasmine-fix'; // eslint-disable-line import/no-extraneous-dependencies
 import linterTslint from '../lib/main';
 

--- a/spec/linter-tslint-spec.js
+++ b/spec/linter-tslint-spec.js
@@ -2,8 +2,9 @@
 
 import * as path from 'path';
 
-const validPath = path.join(__dirname, 'fixtures', 'valid', 'valid.ts');
 const invalidPath = path.join(__dirname, 'fixtures', 'invalid', 'invalid.ts');
+const noConfigPath = path.join(__dirname, 'fixtures', 'no-config', 'noConfig.ts');
+const validPath = path.join(__dirname, 'fixtures', 'valid', 'valid.ts');
 
 describe('The TSLint provider for Linter', () => {
   const lint = require('../lib/main.js').provideLinter().lint;
@@ -45,6 +46,12 @@ describe('The TSLint provider for Linter', () => {
       atom.workspace.open().then(editor => lint(editor)).then((result) => {
         expect(result).toBeNull();
       }),
+    );
+  });
+
+  it('validates even when there is no tslint.json', () => {
+    waitsForPromise(() =>
+      atom.workspace.open(noConfigPath).then(editor => lint(editor)),
     );
   });
 });

--- a/spec/linter-tslint-spec.js
+++ b/spec/linter-tslint-spec.js
@@ -1,57 +1,48 @@
 'use babel';
 
 import * as path from 'path';
+import { beforeEach, it } from 'jasmine-fix'; // eslint-disable-line import/no-extraneous-dependencies
+import linterTslint from '../lib/main';
 
 const invalidPath = path.join(__dirname, 'fixtures', 'invalid', 'invalid.ts');
 const noConfigPath = path.join(__dirname, 'fixtures', 'no-config', 'noConfig.ts');
 const validPath = path.join(__dirname, 'fixtures', 'valid', 'valid.ts');
 
 describe('The TSLint provider for Linter', () => {
-  const lint = require('../lib/main.js').provideLinter().lint;
+  const lint = linterTslint.provideLinter().lint;
 
-  beforeEach(() => {
-    atom.workspace.destroyActivePaneItem();
-
-    waitsForPromise(() =>
-      Promise.all([
-        atom.packages.activatePackage('linter-tslint'),
-      ]),
-    );
+  beforeEach(async () => {
+    await atom.packages.activatePackage('linter-tslint');
   });
 
-  it('finds nothing wrong with a valid file', () => {
-    waitsForPromise(() =>
-      atom.workspace.open(validPath).then(editor => lint(editor)).then((messages) => {
-        expect(messages.length).toBe(0);
-      }),
-    );
-  });
+  describe('When the package is activated', () => {
+    it('finds nothing wrong with a valid file', async () => {
+      const editor = await atom.workspace.open(validPath);
+      const messages = await lint(editor);
+      expect(messages.length).toBe(0);
+    });
 
-  it('handles messages from TSLint', () => {
-    const expectedMsg = 'semicolon - Missing semicolon';
-    waitsForPromise(() =>
-      atom.workspace.open(invalidPath).then(editor => lint(editor)).then((messages) => {
-        expect(messages.length).toBe(1);
-        expect(messages[0].type).toBe('warning');
-        expect(messages[0].html).not.toBeDefined();
-        expect(messages[0].text).toBe(expectedMsg);
-        expect(messages[0].filePath).toBe(invalidPath);
-        expect(messages[0].range).toEqual([[0, 14], [0, 14]]);
-      }),
-    );
-  });
+    it('handles messages from TSLint', async () => {
+      const expectedMsg = 'semicolon - Missing semicolon';
+      const editor = await atom.workspace.open(invalidPath);
+      const messages = await lint(editor);
+      expect(messages.length).toBe(1);
+      expect(messages[0].type).toBe('warning');
+      expect(messages[0].html).not.toBeDefined();
+      expect(messages[0].text).toBe(expectedMsg);
+      expect(messages[0].filePath).toBe(invalidPath);
+      expect(messages[0].range).toEqual([[0, 14], [0, 14]]);
+    });
 
-  it('handles undefined filepath', () => {
-    waitsForPromise(() =>
-      atom.workspace.open().then(editor => lint(editor)).then((result) => {
-        expect(result).toBeNull();
-      }),
-    );
-  });
+    it('handles undefined filepath', async () => {
+      const editor = await atom.workspace.open();
+      const result = await lint(editor);
+      expect(result).toBeNull();
+    });
 
-  it('validates even when there is no tslint.json', () => {
-    waitsForPromise(() =>
-      atom.workspace.open(noConfigPath).then(editor => lint(editor)),
-    );
+    it('finishes validatation even when there is no tslint.json', async () => {
+      const editor = await atom.workspace.open(noConfigPath);
+      await lint(editor);
+    });
   });
 });


### PR DESCRIPTION
Two issues in one:

**Firstly**, there was a regression I caused when copying the `rulesDirectory` code over to worker.js in [#158](https://github.com/AtomLinter/linter-tslint/pull/158). I missed the fact it used to refer to `this.` (which is now `config.`), so a circular reference was caused, which led `tslint` to have kittens, leading to the worker hanging.

**Secondly**, if `tslint` hit an issue, it would cause the worker to hang.