### PR TITLE
Fixing old reference to this.lint() that was left from refactoring in fix on save

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -71,11 +71,9 @@ export default {
         if (textEditor.getRootScopeDescriptor().getScopesArray()
         .some(scope => grammarScopes.includes(scope))) {
           atom.views.getView(textEditor).classList.add(editorClass);
-          textEditor.onDidSave(() => {
+          textEditor.onDidSave(async () => {
             if (atom.config.get('linter-tslint.fixOnSave')) {
-              this.lint(textEditor, {
-                fix: true,
-              });
+              await workerHelper.requestJob('fix', textEditor);
             }
           });
         }


### PR DESCRIPTION
Fixes [#161](https://github.com/AtomLinter/linter-tslint/issues/161)