### PR TITLE
Fixing error handling from worker. Also accounting for errors finding config. file

### DIFF
--- a/lib/worker.js
+++ b/lib/worker.js
@@ -135,43 +135,44 @@ async function lint(content, filePath, options) {
     return null;
   }
 
-  const Linter = await getLinter(filePath);
-  const configurationPath = Linter.findConfigurationPath(null, filePath);
-  const configuration = Linter.loadConfigurationFromPath(configurationPath);
-
-  let { rulesDirectory } = configuration;
-  if (rulesDirectory && configurationPath) {
-    const configurationDir = path.dirname(configurationPath);
-    if (!Array.isArray(rulesDirectory)) {
-      rulesDirectory = [rulesDirectory];
-    }
-    rulesDirectory = rulesDirectory.map((dir) => {
-      if (path.isAbsolute(dir)) {
-        return dir;
-      }
-      return path.join(configurationDir, dir);
-    });
-
-    if (config.rulesDirectory) {
-      rulesDirectory.push(config.rulesDirectory);
-    }
-  }
-
-  let program;
-  if (config.enableSemanticRules && configurationPath) {
-    program = await getProgram(Linter, configurationPath);
-  }
-  const linter = new Linter(Object.assign({
-    formatter: 'json',
-    rulesDirectory,
-  }, options), program);
-
   let lintResult;
   try {
+    const Linter = await getLinter(filePath);
+    const configurationPath = Linter.findConfigurationPath(null, filePath);
+    const configuration = Linter.loadConfigurationFromPath(configurationPath);
+
+    let { rulesDirectory } = configuration;
+    if (rulesDirectory && configurationPath) {
+      const configurationDir = path.dirname(configurationPath);
+      if (!Array.isArray(rulesDirectory)) {
+        rulesDirectory = [rulesDirectory];
+      }
+      rulesDirectory = rulesDirectory.map((dir) => {
+        if (path.isAbsolute(dir)) {
+          return dir;
+        }
+        return path.join(configurationDir, dir);
+      });
+
+      if (config.rulesDirectory) {
+        rulesDirectory.push(config.rulesDirectory);
+      }
+    }
+
+    let program;
+    if (config.enableSemanticRules && configurationPath) {
+      program = await getProgram(Linter, configurationPath);
+    }
+
+    const linter = new Linter(Object.assign({
+      formatter: 'json',
+      rulesDirectory,
+    }, options), program);
+
     linter.lint(filePath, content, configuration);
     lintResult = linter.getResult();
   } catch (err) {
-    console.error(err); // eslint-disable-line no-console
+    console.error(err.message, err.stack); // eslint-disable-line no-console
     lintResult = {};
   }
 


### PR DESCRIPTION
Currently the worker will hang if an error occurs during the finding of the configuration file. This fixes that by moving the `try{}` higher to encompass it.

Also fixing the error sent from the worker task, this allows the stack to show properly.