### PR TITLE
Implement feature request #189 (Option to use global tslint instance)

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -12,6 +12,8 @@ const idleCallbacks = new Set();
 const config = {
   rulesDirectory: null,
   useLocalTslint: false,
+  useGlobalTslint: false,
+  globalNodePath: null,
 };
 
 // Worker still hasn't initialized, since the queued idle callbacks are
@@ -58,6 +60,14 @@ export default {
       atom.config.observe('linter-tslint.enableSemanticRules', (enableSemanticRules) => {
         config.enableSemanticRules = enableSemanticRules;
         workerHelper.changeConfig('enableSemanticRules', enableSemanticRules);
+      }),
+      atom.config.observe('linter-tslint.useGlobalTslint', (use) => {
+        config.useGlobalTslint = use;
+        workerHelper.changeConfig('useGlobalTslint', use);
+      }),
+      atom.config.observe('linter-tslint.globalNodePath', (globalNodePath) => {
+        config.globalNodePath = globalNodePath;
+        workerHelper.changeConfig('globalNodePath', globalNodePath);
       }),
       atom.config.observe('linter-tslint.ignoreTypings', (ignoreTypings) => {
         this.ignoreTypings = ignoreTypings;

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -6,6 +6,8 @@ import escapeHTML from 'escape-html';
 import fs from 'fs';
 import path from 'path';
 import { getRuleUri } from 'tslint-rule-documentation';
+import ChildProcess from 'child_process';
+import getPath from 'consistent-path';
 
 process.title = 'linter-tslint worker';
 
@@ -15,10 +17,10 @@ const config = {
   useLocalTslint: false,
 };
 
-let tslintDef;
+let fallbackLinter;
 let requireResolve;
 
-async function stat(pathname) {
+function stat(pathname) {
   return new Promise((resolve, reject) => {
     fs.stat(pathname, (err, stats) => {
       if (err) {
@@ -58,14 +60,8 @@ function shim(Linter) {
   return LinterShim;
 }
 
-function loadDefaultTSLint() {
-  if (!tslintDef) {
-    // eslint-disable-next-line import/no-dynamic-require
-    tslintDef = require(tslintModuleName).Linter;
-  }
-}
-
-async function getLocalLinter(basedir) {
+function resolveAndCacheLinter(fileDir, moduleDir) {
+  const basedir = moduleDir || fileDir;
   return new Promise((resolve) => {
     if (!requireResolve) {
       requireResolve = require('resolve');
@@ -83,11 +79,26 @@ async function getLocalLinter(basedir) {
             // eslint-disable-next-line import/no-dynamic-require
             linter = require('loophole').allowUnsafeNewFunction(() => require(linterPath).Linter);
           }
-        } else {
-          linter = tslintDef;
+          tslintCache.set(fileDir, linter);
         }
-        tslintCache.set(basedir, linter);
-        return resolve(linter);
+        resolve(linter);
+      },
+    );
+  });
+}
+
+function getNodePrefixPath() {
+  return new Promise((resolve, reject) => {
+    const npmCommand = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+    ChildProcess.exec(
+      `${npmCommand} get prefix`,
+      { env: Object.assign(Object.assign({}, process.env), { PATH: getPath() }) },
+      (err, stdout, stderr) => {
+        if (err || stderr) {
+          reject(err || new Error(stderr));
+        } else {
+          resolve(stdout.trim());
+        }
       },
     );
   });
@@ -99,15 +110,49 @@ async function getLinter(filePath) {
     return tslintCache.get(basedir);
   }
 
-  // Initialize the default instance if it hasn't already been initialized
-  loadDefaultTSLint();
-
   if (config.useLocalTslint) {
-    return getLocalLinter(basedir);
+    const localLint = await resolveAndCacheLinter(basedir);
+    if (localLint) {
+      return localLint;
+    }
   }
 
-  tslintCache.set(basedir, tslintDef);
-  return tslintDef;
+  if (fallbackLinter) {
+    tslintCache.set(basedir, fallbackLinter);
+    return fallbackLinter;
+  }
+
+  if (config.useGlobalTslint) {
+    if (config.globalNodePath) {
+      const globalLint = await resolveAndCacheLinter(basedir, config.globalNodePath);
+      if (globalLint) {
+        fallbackLinter = globalLint;
+        return globalLint;
+      }
+    }
+
+    let prefix;
+    try {
+      prefix = await getNodePrefixPath();
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.warn(`Attempted to load global tslint, but \`npm get prefix\`
+failed. Falling back to the packaged version of tslint. You can specify
+your prefix manually in the settings or linter-tslint config file.\n
+The error message encountered was:\n\n${err.message}`);
+    }
+
+    if (prefix) {
+      const globalLint = await resolveAndCacheLinter(basedir, prefix);
+      fallbackLinter = globalLint;
+      return globalLint;
+    }
+  }
+
+  // eslint-disable-next-line import/no-dynamic-require
+  fallbackLinter = require(tslintModuleName).Linter;
+  tslintCache.set(basedir, fallbackLinter);
+  return fallbackLinter;
 }
 
 async function getProgram(Linter, configurationPath) {
@@ -208,6 +253,8 @@ async function lint(content, filePath, options) {
 export default async function (initialConfig) {
   config.useLocalTslint = initialConfig.useLocalTslint;
   config.enableSemanticRules = initialConfig.enableSemanticRules;
+  config.useGlobalTslint = initialConfig.useGlobalTslint;
+  config.globalNodePath = initialConfig.globalNodePath;
 
   process.on('message', async (message) => {
     if (message.messageType === 'config') {

--- a/package.json
+++ b/package.json
@@ -16,36 +16,56 @@
     "atom": ">=1.14.0 <2.0.0"
   },
   "configSchema": {
-    "rulesDirectory": {
-      "type": "string",
-      "title": "Custom rules directory (absolute path)",
-      "default": ""
-    },
-    "useLocalTslint": {
-      "type": "boolean",
-      "title": "Try using the local tslint package (if exist)",
-      "default": true
-    },
     "enableSemanticRules": {
       "type": "boolean",
       "title": "Enable semantic rules",
       "description": "Allow passing a TypeScript program object to the linter. May negatively affect performance. See this page for details: https://palantir.github.io/tslint/usage/type-checking/",
-      "default": false
+      "default": false,
+      "order": 1
     },
-    "ignoreTypings": {
-      "type": "boolean",
-      "title": "Ignore typings files (.d.ts)",
-      "default": false
+    "rulesDirectory": {
+      "type": "string",
+      "title": "Custom rules directory (absolute path)",
+      "default": "",
+      "order": 2
     },
     "fixOnSave": {
       "title": "Fix errors on save",
       "description": "Have tslint attempt to fix some errors automatically when saving the file.",
       "type": "boolean",
-      "default": false
+      "default": false,
+      "order": 3
+    },
+    "ignoreTypings": {
+      "type": "boolean",
+      "title": "Ignore typings files (.d.ts)",
+      "default": false,
+      "order": 4
+    },
+    "useLocalTslint": {
+      "type": "boolean",
+      "title": "Try to use the project's local tslint package, if it exists",
+      "default": true,
+      "order": 5
+    },
+    "useGlobalTslint": {
+      "type": "boolean",
+      "title": "Use the global tslint install",
+      "description": "If enabled, the global tslint installation will be used as a fallback, instead of the version packaged with linter-tslint.",
+      "default": false,
+      "order": 6
+    },
+    "globalNodePath": {
+      "type": "string",
+      "title": "Global node installation path",
+      "description": "The location of your global npm install. (Will default to `npm get prefix`.)",
+      "default": "",
+      "order": 7
     }
   },
   "dependencies": {
     "atom-package-deps": "^4.3.1",
+    "consistent-path": "^2.0.1",
     "crypto-random-string": "^1.0.0",
     "escape-html": "^1.0.3",
     "loophole": "^1.1.0",


### PR DESCRIPTION
Howdy, all! 👋 

I stumbled across #189 earlier today after wishing for the exact same feature... it's fairly simple and `linter-eslint` already has a similar option, so I decided it was worth wrangling their implementation into `linter-tslint` as well.

There were some minor linting issues with the current codebase due to recent versions of eslint (you can see what I'm talking about in the CI report for #195) so I took the initiative to resolve those as well. Two of them were super minor and well-founded, but the other one introduced by v4.6.0 was a bit silly (as others have [mentioned](https://github.com/eslint/eslint/pull/8102#issuecomment-326848403),) so I went ahead and // eslint-disabled the relevant lines to avoid mucking the style up without a second opinion. Anyway, I hope this is helpful, and any feedback is of course welcome. 😃 👍 