### PR TITLE
Fix invocation of Linter.createProgram() to use full tsconfig path

### DIFF
--- a/lib/worker.js
+++ b/lib/worker.js
@@ -162,7 +162,7 @@ async function getProgram(Linter, configurationPath) {
   try {
     const stats = await stat(tsconfigPath);
     if (stats.isFile()) {
-      program = Linter.createProgram('tsconfig.json', configurationDir);
+      program = Linter.createProgram(tsconfigPath, configurationDir);
     }
   } catch (err) {
     // no-op


### PR DESCRIPTION
See #201 😄