### PR TITLE
lintsOnChange wasn't defined

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -143,7 +143,7 @@ export default {
       name: 'TSLint',
       grammarScopes,
       scope: 'file',
-      lintOnFly: true,
+      lintsOnChange: true,
       lint: async (textEditor) => {
         if (this.ignoreTypings && textEditor.getPath().toLowerCase().endsWith('.d.ts')) {
           return [];


### PR DESCRIPTION
Changing the old `lintOnFly` to `lintsOnChange` was missed as part of #238.

Fixes #247.